### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -177,7 +177,7 @@
 
           {
             services.desktopManager.plasma6.enable = true; # KDE Plasma Desktop Environment
-            programs.dconf.enable = true; # https://nixos.wiki/wiki/KDE#Installation
+            programs.dconf.enable = true; # https://wiki.nixos.org/wiki/KDE#Installation
 
             # ===== DISPLAY MANAGERS =====
             # Only one at a time can be active
@@ -196,7 +196,7 @@
 
           {
             services.desktopManager.plasma6.enable = true; # KDE Plasma Desktop Environment
-            programs.dconf.enable = true; # https://nixos.wiki/wiki/KDE#Installation
+            programs.dconf.enable = true; # https://wiki.nixos.org/wiki/KDE#Installation
 
             # ===== DISPLAY MANAGERS =====
             # Only one at a time can be active

--- a/nixos/hosts/perrrkele/configuration.nix
+++ b/nixos/hosts/perrrkele/configuration.nix
@@ -136,7 +136,7 @@
     EGL_PLATFORM = "wayland";
     EGL_LOG_LEVEL = "fatal";
 
-    # https://nixos.wiki/wiki/Wayland
+    # https://wiki.nixos.org/wiki/Wayland
     MOZ_ENABLE_WAYLAND = "1";
     NIXOS_OZONE_WL = "1";
     LD_BIND_NOW = "1";

--- a/nixos/modules/virtualisation/containerization.nix
+++ b/nixos/modules/virtualisation/containerization.nix
@@ -1,4 +1,4 @@
-# https://nixos.wiki/wiki/Podman
+# https://wiki.nixos.org/wiki/Podman
 
 { ... }:
 
@@ -10,7 +10,7 @@
     # Enable common container config files in /etc/containers
     containers.enable = true;
 
-    # https://nixos.wiki/wiki/Podman
+    # https://wiki.nixos.org/wiki/Podman
     # Options: https://search.nixos.org/options?channel=24.05&show=virtualisation.podman.autoPrune.dates&from=0&size=50&sort=relevance&type=packages&query=virtualisation.podman
     podman = {
       enable = true;


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️